### PR TITLE
Modifier les forms: tous les mêmes et responsive

### DIFF
--- a/app/assets/stylesheets/components/_form.scss
+++ b/app/assets/stylesheets/components/_form.scss
@@ -25,15 +25,23 @@
   }
 }
 
-.form-sign-up {
-  justify-content: center  !important;
-}
-
-.form-sign-up-card {
-  width: 500px !important;
-  box-shadow: 0 0 15px rgba(0,0,0,0.2);
-}
-
 .form-control-label, .form-check-label {
   width: 250px !important;
 }
+
+@media(max-width: 992px) {
+  .form-card {
+    margin-right: 25px;
+  }
+}
+
+@media(max-width: 768px) {
+  .form-container {
+    justify-content: center;
+  }
+  .form-card {
+    width: 80%;
+    margin-right: 0;
+  }
+}
+

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,31 +1,36 @@
-<div class="main-container">
-  <div class="form-container form-sign-up">
-    <div class="form-card form-sign-up-card">
-      <h2>S'enregistrer</h2>
+<%= render "shared/navbar" %>
 
-      <%= simple_form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
-        <%= f.error_notification %>
+<div class="form-banner" style="background-image: linear-gradient(rgba(0,0,0,0.3),rgba(0,0,0,0.2)), url(https://images.unsplash.com/photo-1556089969-9928c26e7edf?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=752&q=80);">
 
-        <div class="form-inputs">
-          <%= f.input :email,
-                      required: true,
-                      autofocus: true,
-                      input_html: { autocomplete: "email" }%>
-          <%= f.input :password, label: "Mot de passe",
-                      required: true,
-                      hint: ("#{@minimum_password_length} caractères minimum" if @minimum_password_length),
-                      input_html: { autocomplete: "new-password" } %>
-          <%= f.input :password_confirmation, label: "Confirmation du mot de passe",
-                      required: true,
-                      input_html: { autocomplete: "new-password" } %>
-        </div>
+  <div class="main-container">
+    <div class="form-container">
+      <div class="form-card">
+        <h2>S'enregistrer</h2>
 
-        <div class="form-actions">
-          <%= f.button :submit, "S'enregistrer", class: "btn btn-secondary mb-2" %>
-        </div>
-      <% end %>
+        <%= simple_form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
+          <%= f.error_notification %>
 
-      <%= render "devise/shared/links" %>
+          <div class="form-inputs">
+            <%= f.input :email,
+                        required: true,
+                        autofocus: true,
+                        input_html: { autocomplete: "email" }%>
+            <%= f.input :password, label: "Mot de passe",
+                        required: true,
+                        hint: ("#{@minimum_password_length} caractères minimum" if @minimum_password_length),
+                        input_html: { autocomplete: "new-password" } %>
+            <%= f.input :password_confirmation, label: "Confirmation du mot de passe",
+                        required: true,
+                        input_html: { autocomplete: "new-password" } %>
+          </div>
+
+          <div class="form-actions">
+            <%= f.button :submit, "S'enregistrer", class: "btn btn-secondary mb-2" %>
+          </div>
+        <% end %>
+
+        <%= render "devise/shared/links" %>
+      </div>
     </div>
   </div>
 </div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,26 +1,31 @@
-<div class="main-container">
-  <div class="form-container form-sign-up">
-    <div class="form-card form-sign-up-card">
-      <h2>Connexion</h2>
+<%= render "shared/navbar" %>
 
-      <%= simple_form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
-        <div class="form-inputs">
-          <%= f.input :email,
-                      required: false,
-                      autofocus: true,
-                      input_html: { autocomplete: "email" } %>
-          <%= f.input :password, label: "Mot de passe",
-                      required: false,
-                      input_html: { autocomplete: "current-password" } %>
-          <%= f.input :remember_me, label: "Se souvenir de moi", as: :boolean if devise_mapping.rememberable? %>
-        </div>
+<div class="form-banner" style="background-image: linear-gradient(rgba(0,0,0,0.3),rgba(0,0,0,0.2)), url(https://images.unsplash.com/photo-1491485880348-85d48a9e5312?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=750&q=80);">
 
-        <div class="form-actions">
-          <%= f.button :submit, "Connexion", class: "btn btn-secondary mb-2" %>
-        </div>
-      <% end %>
+  <div class="main-container">
+    <div class="form-container">
+      <div class="form-card">
+        <h1>Connexion</h1>
 
-      <%= render "devise/shared/links" %>
+        <%= simple_form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
+          <div class="form-inputs">
+            <%= f.input :email,
+                        required: false,
+                        autofocus: true,
+                        input_html: { autocomplete: "email" } %>
+            <%= f.input :password, label: "Mot de passe",
+                        required: false,
+                        input_html: { autocomplete: "current-password" } %>
+            <%= f.input :remember_me, label: "Se souvenir de moi", as: :boolean if devise_mapping.rememberable? %>
+          </div>
+
+          <div class="form-actions">
+            <%= f.button :submit, "Connexion", class: "btn btn-secondary mb-2" %>
+          </div>
+        <% end %>
+
+        <%= render "devise/shared/links" %>
+      </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Les formulaires ajouter un chat, se connecter et s'enregistrer sont tous similaires et responsive: 
En taille normal: 
![Capture d’écran 2019-05-22 à 09 00 56](https://user-images.githubusercontent.com/48632528/58153995-d26c3900-7c70-11e9-9f1c-e68b9a171b88.png)
en taille tablet;
![Capture d’écran 2019-05-22 à 09 01 06](https://user-images.githubusercontent.com/48632528/58154002-d730ed00-7c70-11e9-80d8-fa40fd1d23dc.png)
et en small device:
![Capture d’écran 2019-05-22 à 09 01 12](https://user-images.githubusercontent.com/48632528/58154006-dbf5a100-7c70-11e9-8fcb-14822bde6945.png)
