### PR TITLE
add coordinates to cats

### DIFF
--- a/app/models/cat.rb
+++ b/app/models/cat.rb
@@ -8,4 +8,11 @@ class Cat < ApplicationRecord
   validates :city, presence: true
 
   mount_uploader :photo, PhotoUploader
+
+  geocoded_by :address
+  after_validation :geocode #, if: :will_save_change_to_street?
+
+  def address
+    return "#{self.street}, #{self.postcode}, #{self.city}"
+  end
 end


### PR DESCRIPTION
J'ai fait les réglages dans le modèle cat pour ajouter la latitude et la longitude en fonction de l'adresse. 
On peut maintenant utiliser les méthodes de geocode comme "near" pour trouver les chats près d'une ville en particulier :) 
(testé : ca fonctionne)